### PR TITLE
fix: textinputoutlined component inner padding was working as margins…

### DIFF
--- a/src/components/TextInput/TextInputOutlined.tsx
+++ b/src/components/TextInput/TextInputOutlined.tsx
@@ -60,6 +60,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
       label,
       error,
       selectionColor,
+      inputPadding,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       underlineColor,
       outlineColor: customOutlineColor,
@@ -336,6 +337,7 @@ class TextInputOutlined extends React.Component<ChildTextInputProps> {
                   ? { height: inputHeight }
                   : {},
                 paddingOut,
+                inputPadding,
                 {
                   ...font,
                   fontSize,

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -37,6 +37,7 @@ export type State = {
 };
 export type ChildTextInputProps = {
   parentState: State;
+  inputPadding: {padding?: number, paddingTop?: number, paddingRight?: number, paddingBottom?: number, paddingLeft?: number};
   innerRef: (ref?: NativeTextInput | null) => void;
   onFocus?: (args: any) => void;
   onBlur?: (args: any) => void;


### PR DESCRIPTION
this code fixes inner padding of outlined textInput component